### PR TITLE
added grsecurity USB Denial features

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ for me to use.
     encrypted home+swap partition. Once your machine is powered off. Your data
     is no longer accessible in any manner.
 
+- GRSecurity BadUSB Prevention: If you have GRSecurity patched onto and enabled
+  in your kernel, when slock is started, all new USB devices will be disabled.
+  This requires that the kernel.grsecurity.grsec_lock sysctl option be set to 0,
+  which is a security risk to an attacker with local access. If you enable
+  STRICT\_USBOFF when slock comes on, kernel.grsecurity.grsec_lock will be set
+  to 1 and new USB devices will denied until you reboot.
+
+  You will need to have this line in your /etc/sysctl.d/grsec.conf
+
+        kernel.grsecurity.grsec_lock = 0
+
+  and it also requires the same permissions as Automatic Shutdown in
+  /etc/sudoers.
+
 - Webcam Support (requires ffmpeg): This will take a webcam shot of whoever may
   be tampering with your machine before poweroff.
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ for me to use.
   and it also requires similar permissions to Automatic Shutdown in
   /etc/sudoers.
 
-    - `[username] [hostname] =NOPASSWD: /usr/bin/sysctl kernel.grsecurity.deny_new_usb=1`
-    - `[username] [hostname] =NOPASSWD: /usr/bin/sysctl kernel.grsecurity.deny_new_usb=0`
+    - `[username] [hostname] =NOPASSWD: /sbin/sysctl kernel.grsecurity.deny_new_usb=1`
+    - `[username] [hostname] =NOPASSWD: /sbin/sysctl kernel.grsecurity.deny_new_usb=0`
 
 - Webcam Support (requires ffmpeg): This will take a webcam shot of whoever may
   be tampering with your machine before poweroff.

--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ for me to use.
 
         kernel.grsecurity.grsec_lock = 0
 
-  and it also requires the same permissions as Automatic Shutdown in
+  and it also requires similar permissions as Automatic Shutdown in
   /etc/sudoers.
+
+    - `[username] [hostname] =NOPASSWD: /usr/bin/sysctl kernel.grsecurity.deny_new_usb=1`
+    - `[username] [hostname] =NOPASSWD: /usr/bin/sysctl kernel.grsecurity.deny_new_usb=0`
 
 - Webcam Support (requires ffmpeg): This will take a webcam shot of whoever may
   be tampering with your machine before poweroff.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ for me to use.
 
         kernel.grsecurity.grsec_lock = 0
 
-  and it also requires similar permissions as Automatic Shutdown in
+  and it also requires similar permissions to Automatic Shutdown in
   /etc/sudoers.
 
     - `[username] [hostname] =NOPASSWD: /usr/bin/sysctl kernel.grsecurity.deny_new_usb=1`

--- a/slock.c
+++ b/slock.c
@@ -192,7 +192,7 @@ static void
 usboff(void) {
 #if USBOFF
 	// Needs sudo privileges - alter your /etc/sudoers file:
-	// sysctl: [username] [hostname] =NOPASSWD: /usr/bin/sysctl kernel.grsecurity.deny_new_usb=0
+	// sysctl: [username] [hostname] =NOPASSWD: /usr/bin/sysctl kernel.grsecurity.deny_new_usb=1
 	char *args[] = { "sudo", "sysctl", "kernel.grsecurity.deny_new_usb=1", NULL };
         #if STRICT_USBOFF
                 char *argst[] = { "sudo", "sysctl", "kernel.grsecurity.grsec_lock=1", NULL };

--- a/slock.c
+++ b/slock.c
@@ -192,7 +192,7 @@ static void
 usboff(void) {
 #if USBOFF
 	// Needs sudo privileges - alter your /etc/sudoers file:
-	// sysctl: [username] [hostname] =NOPASSWD: /usr/bin/sysctl kernel.grsecurity.deny_new_usb=1
+	// sysctl: [username] [hostname] =NOPASSWD: /sbin/sysctl kernel.grsecurity.deny_new_usb=1
 	char *args[] = { "sudo", "sysctl", "kernel.grsecurity.deny_new_usb=1", NULL };
         #if STRICT_USBOFF
                 char *argst[] = { "sudo", "sysctl", "kernel.grsecurity.grsec_lock=1", NULL };
@@ -209,7 +209,7 @@ static void
 usbon(void) {
 #if USBOFF
 	// Needs sudo privileges - alter your /etc/sudoers file:
-	// sysctl: [username] [hostname] =NOPASSWD: /usr/bin/sysctl kernel.grsecurity.deny_new_usb=0
+	// sysctl: [username] [hostname] =NOPASSWD: /sbin/sysctl kernel.grsecurity.deny_new_usb=0
 	char *args[] = { "sudo", "sysctl", "kernel.grsecurity.deny_new_usb=0", NULL };
 	execvp(args[0], args);
 #else


### PR DESCRIPTION
I added a BadUSB prevention feature which uses GRSecurity's deny_new_usb sysctl option to disable new USB connections. While this may be superfluous with the 5 password attempt limit, I thought it was cool to try and block USB HID based attacks on the system.